### PR TITLE
Added support for vcd trace files

### DIFF
--- a/src/handlebars/lastlayer.cc.hbs
+++ b/src/handlebars/lastlayer.cc.hbs
@@ -2,6 +2,12 @@
 #include "lastlayer.h"
 #include <cassert>
 
+#ifdef __enable_vcd_dump
+#include <verilated_vcd_c.h>
+VerilatedVcdC *trace = NULL;
+vluint64_t trace_time = 0;
+#endif
+
 vluint64_t main_time = 0;
 
 double sc_time_stamp() { return main_time; }
@@ -11,11 +17,22 @@ extern "C" {
 #endif
 
 LastLayerHandle LastLayerAlloc() {
-    return new V{{vtop}};
+    V{{vtop}}* top = new V{{vtop}};
+#ifdef __enable_vcd_dump
+    Verilated::traceEverOn(true);
+    trace = new VerilatedVcdC;
+    top->trace(trace, 99);
+    trace->open("{{vcd_file}}");
+#endif
+    return static_cast<LastLayerHandle>(top);
 }
 
 void LastLayerDealloc(LastLayerHandle handle) {
     delete static_cast<V{{vtop}}*>(handle);
+#ifdef __enable_vcd_dump
+    trace->close();
+    delete trace;
+#endif
 }
 
 int LastLayerReadReg(LastLayerHandle handle, int hid, int sel) {
@@ -56,8 +73,15 @@ void LastLayerReset(LastLayerHandle handle, int n) {
         }
         top->eval();
         main_time++;
+#ifdef __enable_vcd_dump
+        trace->dump(trace_time+main_time);
+#endif
     }
     top->{{reset}} = 0;
+#ifdef __enable_vcd_dump
+    trace_time += main_time;
+    trace->flush();
+#endif
 }
 
 
@@ -74,7 +98,14 @@ void LastLayerRun(LastLayerHandle handle, int n) {
       }
       top->eval();
       main_time++;
+#ifdef __enable_vcd_dump
+      trace->dump(trace_time+main_time);
+#endif
   }
+#ifdef __enable_vcd_dump
+  trace_time += main_time;
+  trace->flush();
+#endif
 }
 
 #ifdef __cplusplus

--- a/src/handlebars/lastlayer.cc.hbs
+++ b/src/handlebars/lastlayer.cc.hbs
@@ -2,7 +2,7 @@
 #include "lastlayer.h"
 #include <cassert>
 
-#ifdef __enable_vcd_dump
+#ifdef LASTLAYER_VCD
 #include <verilated_vcd_c.h>
 VerilatedVcdC *trace = NULL;
 vluint64_t trace_time = 0;
@@ -18,7 +18,7 @@ extern "C" {
 
 LastLayerHandle LastLayerAlloc() {
     V{{vtop}}* top = new V{{vtop}};
-#ifdef __enable_vcd_dump
+#ifdef LASTLAYER_VCD
     Verilated::traceEverOn(true);
     trace = new VerilatedVcdC;
     top->trace(trace, 99);
@@ -29,7 +29,7 @@ LastLayerHandle LastLayerAlloc() {
 
 void LastLayerDealloc(LastLayerHandle handle) {
     delete static_cast<V{{vtop}}*>(handle);
-#ifdef __enable_vcd_dump
+#ifdef LASTLAYER_VCD
     trace->close();
     delete trace;
 #endif
@@ -73,12 +73,12 @@ void LastLayerReset(LastLayerHandle handle, int n) {
         }
         top->eval();
         main_time++;
-#ifdef __enable_vcd_dump
+#ifdef LASTLAYER_VCD
         trace->dump(trace_time+main_time);
 #endif
     }
     top->{{reset}} = 0;
-#ifdef __enable_vcd_dump
+#ifdef LASTLAYER_VCD
     trace_time += main_time;
     trace->flush();
 #endif
@@ -98,11 +98,11 @@ void LastLayerRun(LastLayerHandle handle, int n) {
       }
       top->eval();
       main_time++;
-#ifdef __enable_vcd_dump
+#ifdef LASTLAYER_VCD
       trace->dump(trace_time+main_time);
 #endif
   }
-#ifdef __enable_vcd_dump
+#ifdef LASTLAYER_VCD
   trace_time += main_time;
   trace->flush();
 #endif

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,7 @@ impl Build {
             cmd.arg(file);
         }
         if self.vcd_file != None {
-            cmd.arg(format!("-D__enable_vcd_dump"));
+            cmd.arg(format!("-DLASTLAYER_VCD"));
         }
         cmd.arg("-o").arg(&out_dir.join(format!("lib{}.so", name)));
         run_cmd(&mut cmd);


### PR DESCRIPTION
When instantiating a new build, the user can specify `.vcd_file("<path>")` to generate a vcd waveform file during simulation. Because vcd file dumping can have a significant performance hit, I use c macros to ensure that traces are only generated when a vcd file is specified.

If this is something you might want to merge at some point, I'm very open to feedback and iterating on it to match any coding style/standards you want.