### PR TITLE
Glob for all verilator generated cxx files.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ chrono = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 libloading = "0.5"
+glob = "0.3.0"
 
 [build-dependencies]
 os_info = "1.2.0"


### PR DESCRIPTION
Current infrastructure doesn't handle cases where verilator outputs cxx files for submodules in the rtl design. Fix uses a simple glob to grab all verilator generated cxx files. 